### PR TITLE
First iteration on Windows installation howto

### DIFF
--- a/common/welcome.tw2
+++ b/common/welcome.tw2
@@ -16,3 +16,4 @@ That being said, let's start with our first question!
 
 - [[Linux->Linux Introduction]]
 - [[Mac->Mac Introduction]]
+- [[Windows->Windows Introduction]]

--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -33,6 +33,12 @@ mac/expert/install_exercism_on_a_mac.tw2
 mac/expert/install_exercism_via_homebrew.tw2
 mac/expert/manual_install.tw2
 
+windows/add_to_path.tw2
+windows/download_64_bit_on_win10.tw2
+windows/introduction.tw2
+windows/open_command_prompt.tw2
+windows/which_version.tw2
+
 ::SharedStylesheet [stylesheet]
 
 img {

--- a/windows/add_to_path.tw2
+++ b/windows/add_to_path.tw2
@@ -1,0 +1,60 @@
+::Moving exercism to PATH on Windows 10
+# Moving exercism to the right folder on Windows 10
+
+To make Exercism usable on your computer, we need to move it to the right folder. Using the Command Prompt we just opened, we are going to open the folder.
+
+## Step 1: Opening the right folder
+### Exercise
+
+In the Command Prompt window, copy & paste:
+
+```
+start %LOCALAPPDATA%\Microsoft\WindowsApps
+```
+
+and hit the 'Enter' key.
+
+### Verify
+
+A new window, showing a folder, will show up. This is where we need to place the `exercism` file. It will look something like this, but it might not be empty for you.
+
+![cmd.exe folder](https://transfer.sh/LwF0S/win10-cmd-folder.png)
+
+
+## Step 2: Moving the `exercism` file
+### Exercise
+
+Find the `exercism` file in the folder we opened earlier, when we downloaded Exercism. From this folder, drag the file (or copy & paste it) to the folder we just opened, labeled `WindowsApps`.
+
+### Verify
+
+In the `WindowsApps` folder, you should now see the `exercism` file. It will look something like this:
+
+![cmd.exe folder](https://transfer.sh/CFWFA/win10-result.png)
+
+
+## Step 3: Verify installation
+### Exercise
+
+Now that we moved the file, we need to check our installation. Open up the Command Prompt window again, and type (or copy & paste):
+
+```
+exercism
+```
+
+and hit the 'Enter' key.
+
+### Verify
+
+After hitting the `Enter` key, the Command Prompt should reply with how the `exercism` command can be used.
+
+![Exercism usage](https://transfer.sh/12ld3l/win10-installed.png)
+
+> Sidenote: As you get the hang of Exercism, you'll get to know more about the commands.
+
+---
+
+## Have you installed Exercism on your computer?
+
+- [[Yes->Installation complete]]
+- [[No->Talk to a Volunteer]]

--- a/windows/download_64_bit_on_win10.tw2
+++ b/windows/download_64_bit_on_win10.tw2
@@ -1,0 +1,55 @@
+::Download and unzip 64-bit version on Windows 10
+# Downloading Exercism on Windows 10
+
+Let's download the latest version of Exercism to get up and running.
+
+## Step 1
+### Exercise
+
+Open your browser (for example, Chrome or Edge) and navigate to
+
+```
+https://github.com/exercism/cli/releases/latest
+```
+
+### Verify
+
+To verify you are on the correct page, you must see a Downloads list when you scroll down.
+
+![Downloads list](https://i.imgur.com/CGpEnUX.png)
+
+
+## Step 2
+### Exercise
+
+On the downloads list, click the file `exercism-windows-64bit.zip` named to download it:
+
+![64-bit download](https://transfer.sh/mwMGe/win10.png)
+
+### Verify
+
+To verify the file was downloaded, you should see a file named `exercism-windows-64bit.tgz` in your `Downloads` folder.
+
+
+## Step 3
+### Exercise
+
+Double click on `exercism-windows-64bit.zip` to open the folder.
+
+### Verify
+
+The folder will show the file `exercism`, and will look something like this:
+
+![Extracted folder](https://transfer.sh/h8C4G/win10-zip.png)
+
+
+## Wrapping up
+
+If you've reached the end of this tutorial without any problems, you should have the Exercism program in your `Downloads` folder!
+
+---
+
+## Were you able to get the Exercism program in your `Downloads` folder?
+
+- [[Yes->Opening the Command Prompt on Windows 10]]
+- [[No->Talk to a Volunteer]]

--- a/windows/introduction.tw2
+++ b/windows/introduction.tw2
@@ -1,0 +1,8 @@
+::Windows Introduction
+# Installing Exercism on Windows
+
+Do you know whether you are using Windows 10?
+
+- [[I am using Windows 10->Download and unzip 64-bit version on Windows 10]]
+- [[I am not using Windows 10->Talk to a Volunteer]]
+- [[I am not sure what verion of Windows I am using->Finding out what version of Windows you are using]]

--- a/windows/open_command_prompt.tw2
+++ b/windows/open_command_prompt.tw2
@@ -1,0 +1,42 @@
+::Opening the Command Prompt on Windows 10
+# Opening the Command Prompt on Windows 10
+
+For Exercism to work, it needs to be in the right folder. The easiest way to move it is using the Command Prompt.
+
+Let's get started by opening the Command Prompt.
+
+---
+
+## Step 1: Opening Start
+### Exercise
+
+Open the Start menu, by clicking the Windows icon in the bottom left corner of your screen.
+
+
+## Step 2: Searching for the Command Prompt
+### Exercise
+With the Start menu open, start typing `cmd.exe` to search for the Command Prompt
+
+### Verify
+
+When searching for `cmd.exe` in the Start menu, your results will look something like this:
+
+![cmd.exe result](https://transfer.sh/rcwkt/win10-cmd.png)
+
+
+## Step 3: Open the Command Prompt
+### Exercise
+Double click the top result, as shown above, to open the Command Prompt.
+
+### Verify
+
+After double clicking, you'll see a window like the one shown here:
+
+![cmd.exe window](https://transfer.sh/jnNbx/win10-cmd-result.png)
+
+---
+
+## Were you able to open the Command Prompt?
+
+- [[Yes->Moving exercism to PATH on Windows 10]]
+- [[No->Talk to a Volunteer]]

--- a/windows/which_version.tw2
+++ b/windows/which_version.tw2
@@ -1,0 +1,15 @@
+::Finding out what version of Windows you are using
+# Finding out what version of Windows you are using
+
+The website [whichbrowser.net](https://whichbrowser.net/) will show you which version of Windows you're running.
+
+The page will look something like this:
+
+![Detecting Windows](https://transfer.sh/y8LPo/win10-detect.png)
+
+---
+
+## Are you running Windows 10?
+
+- [[Yes->Download and unzip 64-bit version on Windows 10]]
+- [[No->Talk to a Volunteer]]


### PR DESCRIPTION
Focussing on what I assume is the happy path, the majority of users nowadays: 64-bit Windows 10. This makes use of a folder that is by default part of the `PATH`, decreasing complexity during installation.

In the future, this could be extended with the Installer path, or an expert path to decrease the verbosity of the steps.

(In anticipation of https://github.com/exercism/interactive-cli-walkthrough/pull/14, I've not updated the compiled version / graph files)

(This implements a first version of #7)