### PR TITLE
Create a quick path past Homebrew Installation

### DIFF
--- a/mac/asking_about_homebrew.tw2
+++ b/mac/asking_about_homebrew.tw2
@@ -1,0 +1,12 @@
+::Asking about Homebrew
+# Installing Homebrew on a Mac
+
+Homebrew is a package manager for the Mac, and it makes the whole Exercism installation process easier. If you want to Exercism manually, [[Manual Installation on a Mac]] would be helpful.
+
+---
+
+## Do you already have Homebrew installed?
+
+- [[Yes->Installing Exercism via Homebrew]]
+- [[I don't know->Verifying Homebrew Installation]]
+- [[No->Installing Homebrew]]

--- a/mac/install_exercism_on_a_mac.tw2
+++ b/mac/install_exercism_on_a_mac.tw2
@@ -7,5 +7,5 @@ To install Exercism on a Mac, we first need to open the terminal.
 
 ## Do you know how to open the terminal?
 
-- [[Yes->Verifying Homebrew Installation]]
+- [[Yes->Asking about Homebrew]]
 - [[No->Opening the Terminal on a Mac]]

--- a/mac/install_homebrew.tw2
+++ b/mac/install_homebrew.tw2
@@ -82,5 +82,6 @@ Once you've reached the end of this tutorial, you should've installed Homebrew o
 ---
 
 ## Were you able to install Homebrew?
-- [[Yes->Verifying Homebrew Installation]]
+- [[Yes->Installing Exercism via Homebrew]]
+- [[I don't know->Verifying Homebrew Installation]]
 - [[No->Installing Homebrew - Troubleshooting]]

--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -12,6 +12,7 @@ linux/tarball.tw2
 mac/introduction.tw2
 mac/opening_the_terminal.tw2
 mac/opening_the_terminal_troubleshooting.tw2
+mac/asking_about_homebrew.tw2
 mac/verifying_homebrew_installation.tw2
 mac/install_homebrew.tw2
 mac/install_homebrew_troubleshooting.tw2


### PR DESCRIPTION
For users who know how to open a terminal, they may know already that they have Homebrew installed.  Allow them to quickly state that and move on.  If they needed help opening the terminal, we continue to help them asses whether Homebrew is installed.

When asking if installing Homebrew was successful, skip verification on "yes", but add "I don't know" which checks.

Works towards #12