### PR TITLE
Windows: Add 3rd option to use Windows Installer

### DIFF
--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -41,6 +41,7 @@ windows/download_64_bit_on_win10.tw2
 windows/introduction.tw2
 windows/open_command_prompt.tw2
 windows/which_version.tw2
+windows/download_cli_installer.tw2
 
 ::SharedStylesheet [stylesheet]
 

--- a/windows/add_to_path.tw2
+++ b/windows/add_to_path.tw2
@@ -57,4 +57,4 @@ After hitting the `Enter` key, the Command Prompt should reply with how the `exe
 ## Have you installed the Exercism CLI on your computer?
 
 - [[Yes->Installation complete]]
-- [[No->Talk to a Volunteer]]
+- [[No->Download CLI Installer for Windows]]

--- a/windows/download_64_bit_on_win10.tw2
+++ b/windows/download_64_bit_on_win10.tw2
@@ -52,4 +52,4 @@ If you've reached the end of this tutorial without any problems, you should have
 ## Were you able to get the program `exercism` in your `Downloads` folder?
 
 - [[Yes->Opening the Command Prompt on Windows 10]]
-- [[No->Talk to a Volunteer]]
+- [[No->Download CLI Installer for Windows]]

--- a/windows/download_cli_installer.tw2
+++ b/windows/download_cli_installer.tw2
@@ -1,0 +1,10 @@
+::Download CLI Installer for Windows
+# Option to install the Exercism CLI using the installer for Windows
+
+* Either you are using a version of Windows that is earlier than version 10.
+* You ran into issues attempting to install the CLI manually and were not successful.
+
+Would you like to try downloading and installing the Exercism CLI by using the CLI installer for Windows?
+
+- [Yes, take me to the download page for the Windows CLI Installer](https://github.com/exercism/windows-installer/releases/latest)
+- [[No thanks.->Talk to a Volunteer]]

--- a/windows/download_cli_installer.tw2
+++ b/windows/download_cli_installer.tw2
@@ -4,7 +4,11 @@
 * Either you are using a version of Windows that is earlier than version 10.
 * You ran into issues attempting to install the CLI manually and were not successful.
 
-Would you like to try downloading and installing the Exercism CLI by using the CLI installer for Windows?
+Use the link below to download and execute the Windows Installer for the Exercism CLI.  A new browser window will be opened when you click this link.  Please return to this browser window and let us know if you were successful.
 
-- [Yes, take me to the download page for the Windows CLI Installer](https://github.com/exercism/windows-installer/releases/latest)
-- [[No thanks.->Talk to a Volunteer]]
+<a href="https://github.com/exercism/windows-installer/releases/latest" target="_blank">https://github.com/exercism/windows-installer/releases/latest</a>
+
+## Were your able to successfully install the Exercism CLI using the Windows Installer?
+
+- [[Yes->Installation complete]]
+- [[No->Talk to a Volunteer]]

--- a/windows/introduction.tw2
+++ b/windows/introduction.tw2
@@ -4,5 +4,5 @@
 Are you using Windows 10?
 
 - [[Yes, I am using Windows 10.->Download and unzip 64-bit version on Windows 10]]
-- [[No, I am not using Windows 10.->Talk to a Volunteer]]
+- [[No, I am not using Windows 10.->Download CLI Installer for Windows]]
 - [[I am not sure what version of Windows I am using.->Finding out what version of Windows you are using]]

--- a/windows/open_command_prompt.tw2
+++ b/windows/open_command_prompt.tw2
@@ -39,4 +39,4 @@ After double clicking, you'll see a window like the one shown here:
 ## Were you able to open the Command Prompt?
 
 - [[Yes->Moving exercism to PATH on Windows 10]]
-- [[No->Talk to a Volunteer]]
+- [[No->Download CLI Installer for Windows]]

--- a/windows/which_version.tw2
+++ b/windows/which_version.tw2
@@ -12,4 +12,4 @@ The page will look something like this:
 ## Are you running Windows 10?
 
 - [[Yes->Download and unzip 64-bit version on Windows 10]]
-- [[No->Talk to a Volunteer]]
+- [[No->Download CLI Installer for Windows]]


### PR DESCRIPTION
per [comment](https://github.com/exercism/interactive-cli-walkthrough/issues/26#issuecomment-390487496)

If the user is not able to follow the steps to install the CLI manually we will provide them with the option of using the Windows Installer to install the CLI for them.
