### PR TITLE
Add therubyracer as an alternative ExecJS runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem "twee2"
 gem "minitest", require: false
 gem "graph", require: false
 gem "rake"
+gem "therubyracer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     graph (2.8.2)
     haml (4.0.7)
       tilt
+    libv8 (3.16.14.19)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     nokogiri (1.8.2)
@@ -27,11 +28,15 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    ref (2.0.0)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     tilt (2.0.8)
     trollop (2.1.2)
@@ -58,6 +63,7 @@ DEPENDENCIES
   graph
   minitest
   rake
+  therubyracer
   twee2
 
 BUNDLED WITH


### PR DESCRIPTION
Closes #27.

As this project was only primarily tested on a Mac, we had the privilege of having a built in ExecJS runtime. An ExecJS runtime is required by `Twee2` during compilation.

In order to accommodate users from different platforms, I decided to add `therubyracer` inside our Gemfile in order to add an ExecJS runtime after they run `bundle install`.