### PR TITLE
Use env var for binary name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,12 @@ end
 
 desc "Compile the walkthrough"
 task :compile do
-  Twee2.build("main.tw2", "compiled.html", format: "Snowman")
+  filename = "compiled.html"
+  binary_name = ENV["BINARY_NAME"] || "exercism"
+
+  Twee2.build("main.tw2", filename, format: "Snowman")
+  contents = File.read(filename).gsub("BINARY_NAME", binary_name)
+  File.open(filename, "wb") do |f|
+    f.puts contents
+  end
 end

--- a/contents/linux/architecture.tw2
+++ b/contents/linux/architecture.tw2
@@ -14,22 +14,22 @@ Hit `Enter` after you’ve pasted in the command and examine the output.
 
 If the output is `x86_64` then you’re on a 64-bit architecture.
 
-The file you’re looking for is `exercism-linux-64bit.tgz`.
+The file you’re looking for is `BINARY_NAME-linux-64bit.tgz`.
 
 ## `i686`
 
 If the output is `i686` then you’re on a 32-bit architecture.
 
-The file you’re looking for is `exercism-linux-32bit.tgz`.
+The file you’re looking for is `BINARY_NAME-linux-32bit.tgz`.
 
 ## `armv5l`, `armv6l`, `armv7l` or `armv8l`
 
 If the output is `armv5l`, `armv6l`, `armv7l`
 or `armv8l` then you’re on an ARM architecture.
 
-The file you’re looking for is `exercism-linux-arm-v5.tgz`,
-`exercism-linux-arm-v6.tgz`, `exercism-linux-arm-v7.tgz`
-or `exercism-linux-arm-v8.tgz` (respectively).
+The file you’re looking for is `BINARY_NAME-linux-arm-v5.tgz`,
+`BINARY_NAME-linux-arm-v6.tgz`, `BINARY_NAME-linux-arm-v7.tgz`
+or `BINARY_NAME-linux-arm-v8.tgz` (respectively).
 
 ## Other
 

--- a/contents/linux/directory.tw2
+++ b/contents/linux/directory.tw2
@@ -10,31 +10,31 @@ First, let’s make sure the directory exists:
 mkdir -p ~/bin
 ```
 
-Next, let’s move the `exercism` executable there:
+Next, let’s move the `BINARY_NAME` executable there:
 
 ```
-mv exercism ~/bin
+mv BINARY_NAME ~/bin
 ```
 
 Make sure everything worked:
 
 ```
-~/bin/exercism
+~/bin/BINARY_NAME
 ```
 
 The above should output something like the below:
 ```
 NAME:
-   exercism - A command line tool to interact with http://exercism.io
+   BINARY_NAME - A command line tool to interact with http://exercism.io
 
 USAGE:
-   exercism [global options] command [command options] [arguments...]
+   BINARY_NAME [global options] command [command options] [arguments...]
 …
 ```
 
 ---
 
-## Did running `~/bin/exercism` outout something like the above?
+## Did running `~/bin/BINARY_NAME` outout something like the above?
 
 - [[Yes->Linux path]]
 - [[No->Talk to a Volunteer]]

--- a/contents/linux/introduction.tw2
+++ b/contents/linux/introduction.tw2
@@ -1,9 +1,9 @@
 ::Linux Introduction
 # Installing Exercism on Linux
 
-To install Exercism on Linux you need to get the `exercism`
+To install Exercism on Linux you need to get the `BINARY_NAME`
 executable; different process architectures have different
-`exercism` executables, so you need to install the
+`BINARY_NAME` executables, so you need to install the
 right exectuable matching your process architecture.
 
 ---

--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -4,7 +4,7 @@
 Note: If you’re not running Bash try to adjust the
 below to your shell or [[Talk to a Volunteer]].
 
-To have the `exercism` executable available everywhere on the
+To have the `BINARY_NAME` executable available everywhere on the
 command line you need to make sure `~/bin` is in your `$PATH`.
 
 There is a chance it’s there already; let’s see whether it is:
@@ -22,26 +22,26 @@ source ~/.bash_profile
 ```
 
 To check whether this worked, go to your home directory
-and try to run `exercism` without providing the path:
+and try to run `BINARY_NAME` without providing the path:
 
 ```
 cd
-exercism
+BINARY_NAME
 ```
 
 The above should output something like the below:
 ```
 NAME:
-   exercism - A command line tool to interact with http://exercism.io
+   BINARY_NAME - A command line tool to interact with http://exercism.io
 
 USAGE:
-   exercism [global options] command [command options] [arguments...]
+   BINARY_NAME [global options] command [command options] [arguments...]
 …
 ```
 
 ---
 
-## Did running `exercism` outout something like the above?
+## Did running `BINARY_NAME` outout something like the above?
 
 - [[Yes->Installation complete]]
 - [[No->Talk to a Volunteer]]

--- a/contents/linux/tarball.tw2
+++ b/contents/linux/tarball.tw2
@@ -19,7 +19,7 @@ click on the downloaded file and select _Extract Here_.
 * If you’re using the command line (use the
 right archive file name for your architecture):
 ```
-tar -xf exercism-linux-64bit.tgz
+tar -xf BINARY_NAME-linux-64bit.tgz
 ```
 
 ---

--- a/contents/mac/add_to_path.tw2
+++ b/contents/mac/add_to_path.tw2
@@ -1,7 +1,7 @@
 ::Add to $PATH on a Mac
 # Add to $PATH on a Mac
 
-In order to for us to run the exercism program from anywhere in our terminal, we need to add its location to the $PATH variable.
+In order to for us to run the BINARY_NAME program from anywhere in our terminal, we need to add its location to the $PATH variable.
 
 ---
 
@@ -28,20 +28,20 @@ source ~/.bash_profile
 Next, paste the following command in your terminal:
 
 ```
-exercism
+BINARY_NAME
 ```
 
 #### Variable updated successfully
 
-If the terminal replies with instructions on how to use the exercism program, you've installed exercism successfully! Give yourself a pat on the back.
+If the terminal replies with instructions on how to use the BINARY_NAME program, you've installed BINARY_NAME successfully! Give yourself a pat on the back.
 
 #### Variable not updated
 
-If the terminal replies saying that the exercism command is not found, it means that the variable wasn't updated.
+If the terminal replies saying that the BINARY_NAME command is not found, it means that the variable wasn't updated.
 
 ### Wrapping up
 
-If you've reached the end of this tutorial without any problems, you have installed exercism successfully!
+If you've reached the end of this tutorial without any problems, you have installed BINARY_NAME successfully!
 
 ---
 

--- a/contents/mac/add_to_path_troubleshooting.tw2
+++ b/contents/mac/add_to_path_troubleshooting.tw2
@@ -1,6 +1,6 @@
 ::Add to $PATH on a Mac - Troubleshooting
 # Add to $PATH on a Mac - Troubleshooting
-Having problems creating adding exercism to the $PATH variable? A solution to your problem may be outlined below.
+Having problems creating adding BINARY_NAME to the $PATH variable? A solution to your problem may be outlined below.
 
 ---
 

--- a/contents/mac/create_bin_folder.tw2
+++ b/contents/mac/create_bin_folder.tw2
@@ -43,18 +43,18 @@ Your terminal should reply with the following message when the folder was not cr
 
 #### Exercise
 
-Once the folder was created, paste in the following command in your terminal to move the exercism program to the `bin` folder:
+Once the folder was created, paste in the following command in your terminal to move the BINARY_NAME program to the `bin` folder:
 
 ```
-mv ~/Downloads/exercism ~/bin
+mv ~/Downloads/BINARY_NAME ~/bin
 ```
 
 #### Verify
 
-To verify whether you've moved the exercism progam correctly, paste in the following command to your terminal:
+To verify whether you've moved the BINARY_NAME progam correctly, paste in the following command to your terminal:
 
 ```
-if [ -f ~/bin/exercism ]; then echo "file moved"; else echo "file not moved"; fi
+if [ -f ~/bin/BINARY_NAME ]; then echo "file moved"; else echo "file not moved"; fi
 ```
 
 ##### File moved
@@ -67,11 +67,11 @@ After pasting in the command, your terminal must reply with `file not moved` if 
 
 ### Wrapping up
 
-If you've reached the end of this tutorial without any problems, you should've created a `bin` folder and moved the exercism program into it!
+If you've reached the end of this tutorial without any problems, you should've created a `bin` folder and moved the BINARY_NAME program into it!
 
 ---
 
-## Were you able to move the exercism program to your `bin` folder?
+## Were you able to move the BINARY_NAME program to your `bin` folder?
 
 - [[Yes->Add to $PATH on a Mac]]
 - [[No->Create bin folder on a Mac - Troubleshooting]]

--- a/contents/mac/create_bin_folder_troubleshooting.tw2
+++ b/contents/mac/create_bin_folder_troubleshooting.tw2
@@ -1,10 +1,10 @@
 ::Create bin folder on a Mac - Troubleshooting
 # Create bin folder on a Mac - Troubleshooting
-Having problems creating and moving exercism to your `bin` folder? A solution to your problem may be outlined below.
+Having problems creating and moving BINARY_NAME to your `bin` folder? A solution to your problem may be outlined below.
 
 ---
 
-## Were you able to move the exercism program to your `bin` folder?
+## Were you able to move the BINARY_NAME program to your `bin` folder?
 
 - [[Yes->Add to $PATH on a Mac]]
 - [[No->Talk to a Volunteer]]

--- a/contents/mac/download_32_bit_version.tw2
+++ b/contents/mac/download_32_bit_version.tw2
@@ -30,7 +30,7 @@ To verify you are on the correct page, you must see a Downloads list when you sc
 On the downloads list, click on the file named:
 
 ```
-exercism-mac-32bit.tgz
+BINARY_NAME-mac-32bit.tgz
 ```
 
 Clicking on it downloads the file.
@@ -44,18 +44,18 @@ If you're unable to find it, here it is on the downloads list:
 To verify whether you've downloaded the right file, you should see the following file in your `Downloads` folder:
 
 ```
-exercism-mac-32bit.tgz
+BINARY_NAME-mac-32bit.tgz
 ```
 
 ### Step 3
 
 #### Exercise
 
-Double click on `exercism-mac-32bit.tgz` in order to extract it.
+Double click on `BINARY_NAME-mac-32bit.tgz` in order to extract it.
 
 #### Verify
 
-To determine whether you've correctly extracted it, you must see a file named `exercism` appear.
+To determine whether you've correctly extracted it, you must see a file named `BINARY_NAME` appear.
 
 To illustrate, your `Downloads` folder should somewhat appear as this:
 

--- a/contents/mac/download_32_bit_version_troubleshooting.tw2
+++ b/contents/mac/download_32_bit_version_troubleshooting.tw2
@@ -1,6 +1,6 @@
 ::Download and unzip 32 bit version on a Mac - Troubleshooting
 # Download Exercism on your Mac - Troubleshooting
-Having problems determining your downloading the 32 bit version of exercism? A solution to your problem may be outlined below.
+Having problems determining your downloading the 32 bit version of BINARY_NAME? A solution to your problem may be outlined below.
 
 ---
 

--- a/contents/mac/download_64_bit_version.tw2
+++ b/contents/mac/download_64_bit_version.tw2
@@ -30,7 +30,7 @@ To verify you are on the correct page, you must see a Downloads list when you sc
 On the downloads list, click on the file named:
 
 ```
-exercism-mac-64bit.tgz
+BINARY_NAME-mac-64bit.tgz
 ```
 
 Clicking on it downloads the file.
@@ -44,18 +44,18 @@ If you're unable to find it, here it is on the downloads list:
 To verify whether you've downloaded the right file, you should see the following file in your `Downloads` folder:
 
 ```
-exercism-mac-64bit.tgz
+BINARY_NAME-mac-64bit.tgz
 ```
 
 ### Step 3
 
 #### Exercise
 
-Double click on `exercism-mac-64bit.tgz` in order to extract it.
+Double click on `BINARY_NAME-mac-64bit.tgz` in order to extract it.
 
 #### Verify
 
-To determine whether you've correctly extracted it, you must see a file named `exercism` appear.
+To determine whether you've correctly extracted it, you must see a file named `BINARY_NAME` appear.
 
 To illustrate, your `Downloads` folder should somewhat appear as this:
 

--- a/contents/mac/download_64_bit_version_troubleshooting.tw2
+++ b/contents/mac/download_64_bit_version_troubleshooting.tw2
@@ -1,6 +1,6 @@
 ::Download and unzip 64 bit version on a Mac - Troubleshooting
 # Download Exercism on your Mac - Troubleshooting
-Having problems determining your downloading the 64 bit version of exercism? A solution to your problem may be outlined below.
+Having problems determining your downloading the 64 bit version of BINARY_NAME? A solution to your problem may be outlined below.
 
 ---
 

--- a/contents/mac/expert/install_exercism_on_a_mac.tw2
+++ b/contents/mac/expert/install_exercism_on_a_mac.tw2
@@ -1,7 +1,7 @@
 ::Installing Exercism on a Mac - Expert
 # Installing Exercism on a Mac
 
-Do you want to use homebrew to install exercism?
+Do you want to use homebrew to install BINARY_NAME?
 
 - [[Yes->Installing Exercism via Homebrew - Expert]]
 - [[No->Manual Installation on a Mac - Expert]]

--- a/contents/mac/expert/install_exercism_via_homebrew.tw2
+++ b/contents/mac/expert/install_exercism_via_homebrew.tw2
@@ -1,16 +1,16 @@
 ::Installing Exercism via Homebrew - Expert
 # Installing Exercism via Homebrew
 
-To install exercism, simply run:
+To install BINARY_NAME, simply run:
 
 ```
-brew update && brew install exercism
+brew update && brew install BINARY_NAME
 ```
 
 Verify that it was installed properly by running:
 
 ```
-exercism version
+BINARY_NAME version
 ```
 
 ---

--- a/contents/mac/expert/manual_install.tw2
+++ b/contents/mac/expert/manual_install.tw2
@@ -1,13 +1,13 @@
 ::Manual Installation on a Mac - Expert
 # Installing Exercism on a Mac manually
 
-1. Download the appropriate version of exercism based on your processor architecture at the [releases page](https://github.com/exercism/cli/releases/latest).
+1. Download the appropriate version of BINARY_NAME based on your processor architecture at the [releases page](https://github.com/exercism/cli/releases/latest).
 2. Unzip and put the binary in your path.
 
 After that, verify that it was installed properly by running:
 
 ```
-exercism version
+BINARY_NAME version
 ```
 
 ----

--- a/contents/mac/install_exercism_via_homebrew.tw2
+++ b/contents/mac/install_exercism_via_homebrew.tw2
@@ -15,7 +15,7 @@ You've made it to the last step! Since we've got the parts to install Exercism, 
 Paste in the following text into your terminal:
 
 ```
-brew install exercism
+brew install BINARY_NAME
 ```
 
 ![Installing Exercism](https://lh3.googleusercontent.com/kj6aOKeithlvAr8vPs4-mKD-zdfvHImZb3m49tawgopR6_nEEuKnR6cJiG-7qQSy8Xrvt_wECw=w580)
@@ -46,10 +46,10 @@ If your installation is taking too long, we recommend checking your internet con
 
 #### Exercise
 
-In order to verify whether exercism was successfully installed, paste the following text into your terminal.
+In order to verify whether BINARY_NAME was successfully installed, paste the following text into your terminal.
 
 ```
-exercism
+BINARY_NAME
 ```
 
 After typing in the command, hit the `Enter` key.
@@ -58,7 +58,7 @@ After typing in the command, hit the `Enter` key.
 
 ##### Installation successful
 
-After hitting the `Enter` key, the terminal should reply with how the `exercism` command can be used.
+After hitting the `Enter` key, the terminal should reply with how the `BINARY_NAME` command can be used.
 
 ![Exercism usage](https://i.imgur.com/hy4QmaJ.png)
 
@@ -66,11 +66,11 @@ After hitting the `Enter` key, the terminal should reply with how the `exercism`
 
 ##### Installation unsuccessful
 
-After hitting the `Enter` key, the terminal still doesn't recognize the `exercism` command.
+After hitting the `Enter` key, the terminal still doesn't recognize the `BINARY_NAME` command.
 
 ![Exercism not installed](https://i.imgur.com/HWfY57R.png)
 
-> Sidenote: The messages might vary per computer, but if the message you receive means that the terminal couldn't understand the `exercism` command, you have to try installing again.
+> Sidenote: The messages might vary per computer, but if the message you receive means that the terminal couldn't understand the `BINARY_NAME` command, you have to try installing again.
 
 If you've encountered this, we recommend trying to install again. It might work this time!
 

--- a/contents/windows/add_to_path.tw2
+++ b/contents/windows/add_to_path.tw2
@@ -1,7 +1,7 @@
-::Moving exercism to PATH on Windows 10
+::Moving BINARY_NAME to PATH on Windows 10
 # Moving the Exercism CLI to the right folder on Windows 10
 
-To make the Exercism CLI usable on your computer, we need to move the `exercism` executable file to the correct folder. Using the Command Prompt we just opened, we are going to open the folder.
+To make the Exercism CLI usable on your computer, we need to move the `BINARY_NAME` executable file to the correct folder. Using the Command Prompt we just opened, we are going to open the folder.
 
 ## Step 1: Opening the right folder
 ### Exercise
@@ -16,19 +16,19 @@ and hit the 'Enter' key.
 
 ### Verify
 
-A new window, showing a folder, will show up. This is where we need to place the `exercism` file. It will look something like this, but it might not be empty for you.
+A new window, showing a folder, will show up. This is where we need to place the `BINARY_NAME` file. It will look something like this, but it might not be empty for you.
 
 ![cmd.exe folder](https://transfer.sh/LwF0S/win10-cmd-folder.png)
 
 
-## Step 2: Moving the `exercism` file
+## Step 2: Moving the `BINARY_NAME` file
 ### Exercise
 
-Find the `exercism` file in the folder we opened earlier, when we downloaded `exercism`. From this folder, drag the file (or copy & paste it) to the folder we just opened, labeled `WindowsApps`.
+Find the `BINARY_NAME` file in the folder we opened earlier, when we downloaded `BINARY_NAME`. From this folder, drag the file (or copy & paste it) to the folder we just opened, labeled `WindowsApps`.
 
 ### Verify
 
-In the `WindowsApps` folder, you should now see the `exercism` file. It will look something like this:
+In the `WindowsApps` folder, you should now see the `BINARY_NAME` file. It will look something like this:
 
 ![cmd.exe folder](https://transfer.sh/CFWFA/win10-result.png)
 
@@ -39,14 +39,14 @@ In the `WindowsApps` folder, you should now see the `exercism` file. It will loo
 Now that we moved the file, we need to check our installation. Open up the Command Prompt window again, and type (or copy & paste):
 
 ```
-exercism
+BINARY_NAME
 ```
 
 and hit the 'Enter' key.
 
 ### Verify
 
-After hitting the `Enter` key, the Command Prompt should reply with how the `exercism` command can be used.
+After hitting the `Enter` key, the Command Prompt should reply with how the `BINARY_NAME` command can be used.
 
 ![Exercism usage](https://transfer.sh/12ld3l/win10-installed.png)
 

--- a/contents/windows/download_64_bit_on_win10.tw2
+++ b/contents/windows/download_64_bit_on_win10.tw2
@@ -22,34 +22,34 @@ To verify you are on the correct page, you must see a Downloads list when you sc
 ## Step 2
 ### Exercise
 
-On the downloads list, click the file named `exercism-windows-64bit.zip` to download it:
+On the downloads list, click the file named `BINARY_NAME-windows-64bit.zip` to download it:
 
 ![64-bit download](https://transfer.sh/mwMGe/win10.png)
 
 ### Verify
 
-To verify the file was downloaded, you should see a file named `exercism-windows-64bit.zip` in your `Downloads` folder.
+To verify the file was downloaded, you should see a file named `BINARY_NAME-windows-64bit.zip` in your `Downloads` folder.
 
 
 ## Step 3
 ### Exercise
 
-Double click on `exercism-windows-64bit.zip` to open the folder.
+Double click on `BINARY_NAME-windows-64bit.zip` to open the folder.
 
 ### Verify
 
-The folder will show the file `exercism`, and will look something like this:
+The folder will show the file `BINARY_NAME`, and will look something like this:
 
 ![Extracted folder](https://transfer.sh/h8C4G/win10-zip.png)
 
 
 ## Wrapping up
 
-If you've reached the end of this tutorial without any problems, you should have the program `exercism` in your `Downloads` folder!
+If you've reached the end of this tutorial without any problems, you should have the program `BINARY_NAME` in your `Downloads` folder!
 
 ---
 
-## Were you able to get the program `exercism` in your `Downloads` folder?
+## Were you able to get the program `BINARY_NAME` in your `Downloads` folder?
 
 - [[Yes->Opening the Command Prompt on Windows 10]]
 - [[No->Download CLI Installer for Windows]]

--- a/contents/windows/open_command_prompt.tw2
+++ b/contents/windows/open_command_prompt.tw2
@@ -38,5 +38,5 @@ After double clicking, you'll see a window like the one shown here:
 
 ## Were you able to open the Command Prompt?
 
-- [[Yes->Moving exercism to PATH on Windows 10]]
+- [[Yes->Moving BINARY_NAME to PATH on Windows 10]]
 - [[No->Download CLI Installer for Windows]]


### PR DESCRIPTION
During the beta we need the instructions to refer to nextercism, whereas once we
go live we need to refer to exercism.

To make the transition as simple as possible, this uses an optional environment variable
(defaults to exercism).