### PR TITLE
Add configuration step after installing the CLI

### DIFF
--- a/contents/common/cli_install_complete.tw2
+++ b/contents/common/cli_install_complete.tw2
@@ -1,0 +1,5 @@
+::CLI Installation complete
+# CLI Installation complete
+Congratulations, you've now installed Exercism on your computer! Our next step is to configure the CLI.
+
+[[Configure the CLI->Configuring the CLI]]

--- a/contents/common/configuring_the_cli.tw2
+++ b/contents/common/configuring_the_cli.tw2
@@ -1,0 +1,27 @@
+::Configuring the CLI
+# Configuring the CLI
+
+## Tutorial
+
+### Step 1
+
+#### Exercise
+
+In order to configure the CLI, paste in the following text into your terminal:
+
+```
+[CONFIGURE_COMMAND]
+```
+
+After typing in the command, hit the `Enter` key.
+
+#### Verify
+
+After hitting the `Enter` key, you should see that the it notifies you that a configuration file has been written.
+
+---
+
+## Have you installed the Exercism CLI on your computer?
+
+- [[Yes->Installation complete]]
+- [[No->Configuring the CLI - Troubleshooting]]

--- a/contents/common/configuring_the_cli_troubleshooting.tw2
+++ b/contents/common/configuring_the_cli_troubleshooting.tw2
@@ -1,0 +1,11 @@
+::Configuring the CLI - Troubleshooting
+# Configuring the CLI - Troubleshooting
+
+Having problems configuring the CLI? A solution to your problem may be outlined below.
+
+---
+
+## Were you able to configure the CLI?
+
+- [[Yes->Installation complete]]
+- [[No->Talk to a Volunteer]]

--- a/contents/common/install_complete.tw2
+++ b/contents/common/install_complete.tw2
@@ -1,5 +1,3 @@
 ::Installation complete
 # Installation complete
-You've now installed Exercism on your computer. Start learning by choosing an exercise from your dashboard!
-
-
+Congratulations, you now have everything set up! Start learning by choosing an exercise from your dashboard!

--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -43,5 +43,5 @@ USAGE:
 
 ## Did running `BINARY_NAME` outout something like the above?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]

--- a/contents/mac/add_to_path.tw2
+++ b/contents/mac/add_to_path.tw2
@@ -47,5 +47,5 @@ If you've reached the end of this tutorial without any problems, you have instal
 
 ## Were you able to install Exercism?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Add to $PATH on a Mac - Troubleshooting]]

--- a/contents/mac/add_to_path_troubleshooting.tw2
+++ b/contents/mac/add_to_path_troubleshooting.tw2
@@ -6,5 +6,5 @@ Having problems creating adding BINARY_NAME to the $PATH variable? A solution to
 
 ## Were you able to install Exercism?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]

--- a/contents/mac/expert/install_exercism_via_homebrew.tw2
+++ b/contents/mac/expert/install_exercism_via_homebrew.tw2
@@ -16,5 +16,5 @@ BINARY_NAME version
 ---
 ## Have you installed Exercism on your computer?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Installing Exercism via Homebrew - Expert - Troubleshooting]]

--- a/contents/mac/expert/install_exercism_via_homebrew_troubleshooting.tw2
+++ b/contents/mac/expert/install_exercism_via_homebrew_troubleshooting.tw2
@@ -9,5 +9,5 @@ Here there is a list of Homebrew - Common Issues that can help: https://docs.bre
 
 ## Were you able to install Exercism?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]

--- a/contents/mac/expert/manual_install.tw2
+++ b/contents/mac/expert/manual_install.tw2
@@ -13,6 +13,6 @@ BINARY_NAME version
 ----
 ## Have you installed Exercism on your computer?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]
 - [[I don't know my processor architecture->Determine processor architecture on a Mac - Expert]]

--- a/contents/mac/install_exercism_via_homebrew.tw2
+++ b/contents/mac/install_exercism_via_homebrew.tw2
@@ -82,5 +82,5 @@ Once you've reached the end of this tutorial, you should've installed Exercism o
 
 ## Have you installed Exercism on your computer?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Installing Exercism via Homebrew - Troubleshooting]]

--- a/contents/mac/install_exercism_via_homebrew_troubleshooting.tw2
+++ b/contents/mac/install_exercism_via_homebrew_troubleshooting.tw2
@@ -6,6 +6,6 @@ Having problems getting Exercism on your computer? A solution to your problem ma
 
 ## Were you able to install Exercism?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]
 - [[Try another installation method->Manual Installation on a Mac]]

--- a/contents/windows/add_to_path.tw2
+++ b/contents/windows/add_to_path.tw2
@@ -56,5 +56,5 @@ After hitting the `Enter` key, the Command Prompt should reply with how the `BIN
 
 ## Have you installed the Exercism CLI on your computer?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Download CLI Installer for Windows]]

--- a/contents/windows/download_cli_installer.tw2
+++ b/contents/windows/download_cli_installer.tw2
@@ -10,5 +10,5 @@ Use the link below to download and execute the Windows Installer for the Exercis
 
 ## Were your able to successfully install the Exercism CLI using the Windows Installer?
 
-- [[Yes->Installation complete]]
+- [[Yes->CLI Installation complete]]
 - [[No->Talk to a Volunteer]]

--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -1,7 +1,10 @@
 ::StoryIncludes
 contents/common/welcome.tw2
 contents/common/install_complete.tw2
+contents/common/cli_install_complete.tw2
 contents/common/talk_to_a_volunteer.tw2
+contents/common/configuring_the_cli.tw2
+contents/common/configuring_the_cli_troubleshooting.tw2
 
 contents/linux/architecture.tw2
 contents/linux/directory.tw2


### PR DESCRIPTION
## Description
This adds the configuration step after installing the CLI. As each configuration command is personalized, a token `[CONFIGURE_COMMAND]` is put in and will be substituted with the right command. (PR [here](https://github.com/exercism/prototype/pull/81))

This step appears after the user has installed the CLI and will have the same steps regardless of their platform. I'm not actually sure if this is correct.