### PR TITLE
Bypass the homebrew instructions for launch

### DIFF
--- a/contents/mac/expert/install_exercism_on_a_mac.tw2
+++ b/contents/mac/expert/install_exercism_on_a_mac.tw2
@@ -1,7 +1,4 @@
 ::Installing Exercism on a Mac - Expert
 # Installing Exercism on a Mac
 
-Do you want to use homebrew to install BINARY_NAME?
-
-- [[Yes->Installing Exercism via Homebrew - Expert]]
-- [[No->Manual Installation on a Mac - Expert]]
+- [[Manual Installation on a Mac->Manual Installation on a Mac - Expert]]

--- a/contents/mac/install_exercism_on_a_mac.tw2
+++ b/contents/mac/install_exercism_on_a_mac.tw2
@@ -7,5 +7,5 @@ To install Exercism on a Mac, we first need to open the terminal.
 
 ## Do you know how to open the terminal?
 
-- [[Yes->Asking about Homebrew]]
+- [[Yes->Manual Installation on a Mac]]
 - [[No->Opening the Terminal on a Mac]]

--- a/contents/mac/introduction.tw2
+++ b/contents/mac/introduction.tw2
@@ -3,5 +3,5 @@
 
 Are you comfortable installing and executing programs on terminal?
 
-- [[Yes->Installing Exercism on a Mac - Expert]]
+- [[Yes->Manual Installation on a Mac - Expert]]
 - [[No->Installing Exercism on a Mac]]

--- a/contents/mac/opening_the_terminal.tw2
+++ b/contents/mac/opening_the_terminal.tw2
@@ -43,5 +43,5 @@ If you've reached the end of this tutorial without any problems, you've successf
 
 ## Were you able to open the terminal?
 
-- [[Yes->Verifying Homebrew Installation]]
+- [[Yes->Manual Installation on a Mac]]
 - [[No->Open the Terminal on a Mac - Troubleshooting]]

--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -29,8 +29,6 @@ contents/mac/add_to_path_troubleshooting.tw2
 contents/mac/install_exercism_on_a_mac.tw2
 contents/mac/expert/determine_processor_architecture.tw2
 contents/mac/expert/install_exercism_on_a_mac.tw2
-contents/mac/expert/install_exercism_via_homebrew.tw2
-contents/mac/expert/install_exercism_via_homebrew_troubleshooting.tw2
 contents/mac/expert/manual_install.tw2
 
 contents/windows/add_to_path.tw2

--- a/table_of_contents.tw2
+++ b/table_of_contents.tw2
@@ -15,12 +15,6 @@ contents/linux/tarball.tw2
 contents/mac/introduction.tw2
 contents/mac/opening_the_terminal.tw2
 contents/mac/opening_the_terminal_troubleshooting.tw2
-contents/mac/asking_about_homebrew.tw2
-contents/mac/verifying_homebrew_installation.tw2
-contents/mac/install_homebrew.tw2
-contents/mac/install_homebrew_troubleshooting.tw2
-contents/mac/install_exercism_via_homebrew.tw2
-contents/mac/install_exercism_via_homebrew_troubleshooting.tw2
 contents/mac/manual_install.tw2
 contents/mac/determine_processor_architecture.tw2
 contents/mac/determine_processor_architecture_troubleshooting.tw2


### PR DESCRIPTION
We've not yet submitted the new CLI to homebrew.
Once we do, we can revert this commit to go back to where we were.