### PR TITLE
Point back to the detailed instructions in Mac/Expert section

### DIFF
--- a/contents/mac/expert/manual_install.tw2
+++ b/contents/mac/expert/manual_install.tw2
@@ -15,5 +15,5 @@ BINARY_NAME version
 ## Have you installed Exercism on your computer?
 
 - [[Yes->CLI Installation complete]]
-- [[No->Talk to a Volunteer]]
 - [[I don't know my processor architecture->Determine processor architecture on a Mac - Expert]]
+- [[How do I put the binary in my path?->Create bin folder on a Mac]]


### PR DESCRIPTION
We ask people if they are comfortable installing things on the
command-line. When they say yes, we tell them to download an archive,
unpack it, and stick it in their path.

In so many words. Basically.

It turns out, a lot of people who say "yes" to being comfortable
don't know what the PATH is. So they're not scared of the terminal,
which is great, but they are also now at a dead end, which is not
great.

This points them back into the detailed part of the process if
they don't know what a PATH is. I am pointing to the "create a bin
folder" rather than "add bin to your path", since that is most likely
where they fell off.