### PR TITLE
Tweak rake task names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,35 +6,42 @@ task :graph do
   BuildGraph.()
 end
 
-desc "Compile the walkthrough"
-task :compile do
-  STDERR.puts "Use 'rake compile_prod' to compile for production!"
+namespace :compile do
+  desc "Compile the walkthrough for development"
+  task :dev do
+    STDERR.puts "Use 'rake compile:prod' to compile for production!"
 
-  filename = "compiled.html"
-  binary_name = ENV["BINARY_NAME"] || "exercism"
-  walkthrough_assets_path = ENV["WALKTHROUGH_ASSETS_PATH"] || "#{Dir.pwd}/contents/assets"
+    filename = "compiled.html"
+    binary_name = ENV["BINARY_NAME"] || "exercism"
+    walkthrough_assets_path = ENV["WALKTHROUGH_ASSETS_PATH"] || "#{Dir.pwd}/contents/assets"
 
-  Twee2.build("main.tw2", filename)
+    Twee2.build("main.tw2", filename)
 
-  contents = File.read(filename).gsub("BINARY_NAME", binary_name)
-  contents = contents.gsub("WALKTHROUGH_ASSETS_PATH", walkthrough_assets_path)
+    contents = File.read(filename).gsub("BINARY_NAME", binary_name)
+    contents = contents.gsub("WALKTHROUGH_ASSETS_PATH", walkthrough_assets_path)
 
-  File.open(filename, "wb") do |f|
-    f.puts contents
+    File.open(filename, "wb") do |f|
+      f.puts contents
+    end
+  end
+
+  desc "Compile the walkthrough for production"
+  task :prod do
+    filename = "compiled_prod.html"
+    binary_name = ENV["BINARY_NAME"] || "exercism"
+    walkthrough_assets_path = "https://raw.githubusercontent.com/exercism/interactive-cli-walkthrough/master/contents/assets"
+    Twee2.build("main.tw2", filename)
+
+    contents = File.read(filename).gsub("BINARY_NAME", binary_name)
+    contents = contents.gsub("WALKTHROUGH_ASSETS_PATH", walkthrough_assets_path)
+
+    File.open(filename, "wb") do |f|
+      f.puts contents
+    end
   end
 end
 
-desc "Compile the walkthrough for production"
-task :compile_prod do
-  filename = "compiled_prod.html"
-  binary_name = ENV["BINARY_NAME"] || "exercism"
-  walkthrough_assets_path = "https://raw.githubusercontent.com/exercism/interactive-cli-walkthrough/master/contents/assets"
-  Twee2.build("main.tw2", filename)
-
-  contents = File.read(filename).gsub("BINARY_NAME", binary_name)
-  contents = contents.gsub("WALKTHROUGH_ASSETS_PATH", walkthrough_assets_path)
-
-  File.open(filename, "wb") do |f|
-    f.puts contents
-  end
+desc "Compile the walkthrough for development (alias for compile:dev)"
+task :compile do
+  Rake::Task['compile:dev'].invoke
 end


### PR DESCRIPTION
This gives us three tasks:

    rake compile
    rake compile:dev
    rake compile:prod

The first one is an alias for 'compile:dev'.

This is slightly more idiomatic than having 'compile' and 'compile_prod'

FYI @kntsoriano -- I'm going to merge this, but wanted you to be aware of the change.