### PR TITLE
Make checking the PATH more tolerant and properly quote an echo

### DIFF
--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -10,7 +10,7 @@ command line you need to make sure `~/bin` is in your `$PATH`.
 There is a chance it’s there already; let’s see whether it is:
 
 ```
-[[ ":$PATH:" == *":$HOME/bin:"* ]] && echo "~/bin is in PATH" || echo "~/bin is not in PATH"
+[[ ":$PATH:" == *":$HOME/bin:"* || ":$PATH:" == *":~/bin:"* ]] && echo "~/bin is in PATH" || echo "~/bin is not in PATH"
 ```
 
 If the above prints `~/bin is not in PATH` let’s add

--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -17,7 +17,7 @@ If the above prints `~/bin is not in PATH` let’s add
 `~/bin` to `$PATH` and reload Bash configuration:
 
 ```
-echo "export PATH=~/bin:$PATH" >> ~/.bash_profile
+echo 'export PATH=~/bin:$PATH' >> ~/.bash_profile
 source ~/.bash_profile
 ```
 


### PR DESCRIPTION
The check whether `~/bin` is already in PATH missed if `~/bin` (literally) was in PATH.

Also the way the `echo` was quoted before lead to early expansion and the fully expanded PATH was written to the profile.

This has at least the following two issues:

1. In inheritted environments former changes to PATH were overwritten
2. When the old PATH contained spaces (and possibly other quoted characters), invalid bash-syntax was generated.

I have not checked yet, but there may be similar issues in the MacOS instructions.