### PR TITLE
Add an explicit tilde to cd into home

### DIFF
--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -25,7 +25,7 @@ To check whether this worked, go to your home directory
 and try to run `BINARY_NAME` without providing the path:
 
 ```
-cd
+cd ~
 BINARY_NAME
 ```
 


### PR DESCRIPTION
`cd` without any arguments has unspecified behaviour when `HOME` is not set. Also this step was mistaken by students as `cd exercism` (despite the fact both was on separate lines) and lead to confusion.

Hopefully the added tilde (`~`) will bring clarification.