### PR TITLE
Dont change working directory when testing for cli installation

### DIFF
--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -25,7 +25,6 @@ To check whether this worked, go to your home directory
 and try to run `BINARY_NAME` without providing the path:
 
 ```
-cd ~
 BINARY_NAME
 ```
 


### PR DESCRIPTION
Closes https://github.com/exercism/exercism/issues/4483.

The discussion on why this change was done is outlined in the issue above.