### PR TITLE
Fix wrongly labelled link

### DIFF
--- a/contents/mac/expert/determine_processor_architecture.tw2
+++ b/contents/mac/expert/determine_processor_architecture.tw2
@@ -17,5 +17,5 @@ Also, all computers with more than 4 GB of memory has to have a 64 bit processor
 ---
 ## Do you know your processor architecture?
 
-- [[Yes->Manual Installation on a Mac - Expert]]
+- [[Yes->Manual Installation on a Mac]]
 - [[I don't know->Talk to a Volunteer]]


### PR DESCRIPTION
This fixes this issue: https://github.com/exercism/exercism/issues/5290.

I'm going to merge this right away as I'm confident that this fixes this issue.