### PR TITLE
fix typo in process -> processor

### DIFF
--- a/contents/linux/architecture.tw2
+++ b/contents/linux/architecture.tw2
@@ -1,7 +1,7 @@
 ::Linux architecture
-# Determine process architecture on Linux
+# Determine processor architecture on Linux
 
-To determine your process architecture, paste
+To determine your processor architecture, paste
 in the following command into your terminal:
 
 ```
@@ -37,7 +37,7 @@ If your output does not match any of the above, try talk to a volunteer.
 
 ---
 
-## Do you know your system’s process architecture?
+## Do you know your system’s processor architecture?
 
 - [[Yes->Linux tarball]]
 - [[No, I would like talk to a volunteer->Talk to a Volunteer]]

--- a/contents/linux/tarball.tw2
+++ b/contents/linux/tarball.tw2
@@ -3,7 +3,7 @@
 
 ## Download the archive
 
-If you know your process architecture (x86 (32-bit) vs x86_64 (64-bit) vs ARM), download the appropriate archive from the
+If you know your processor architecture (x86 (32-bit) vs x86_64 (64-bit) vs ARM), download the appropriate archive from the
 <a href="https://github.com/exercism/cli/releases/latest" target="_blank">releases page</a>.
 
 
@@ -27,4 +27,4 @@ tar -xf BINARY_NAME-linux-64bit.tgz
 ## Next steps:
 
 - [[Continue->Linux directory]]
-- [[I don’t know my process architecture->Linux architecture]]
+- [[I don’t know my processor architecture->Linux architecture]]


### PR DESCRIPTION
Fixes typo in selecting CLI for your system's CPU architecture


Fixes https://github.com/exercism/exercism/issues/6605