### PR TITLE
Rename CLI version to v3

### DIFF
--- a/contents/linux/directory.tw2
+++ b/contents/linux/directory.tw2
@@ -24,7 +24,7 @@ Make sure everything worked:
 The above should output something like the below:
 
 ```
-A command-line interface for the v2 redesign of Exercism.
+A command-line interface for the v3 redesign of Exercism.
 
 Download exercises and submit your solutions.
 

--- a/contents/linux/path.tw2
+++ b/contents/linux/path.tw2
@@ -30,7 +30,7 @@ BINARY_NAME
 The above should output something like the below:
 
 ```
-A command-line interface for the v2 redesign of Exercism.
+A command-line interface for the v3 redesign of Exercism.
 
 Download exercises and submit your solutions.
 


### PR DESCRIPTION
CLI output in docs has shown `v2`, while the CLI actually shows `v3`.

This PR changes the docs accordingly.